### PR TITLE
Getting Segments Working

### DIFF
--- a/shepherd_bms/lib/LTC/LTC68041.cpp
+++ b/shepherd_bms/lib/LTC/LTC68041.cpp
@@ -1161,7 +1161,7 @@ void LTC6804_stcomm(uint8_t len) //Length of data to be transmitted
 	cmd[2] = (uint8_t)(cmd_pec >> 8);
 	cmd[3] = (uint8_t)(cmd_pec);
 
-  //wakeup_idle();
+  wakeup_idle();
 	digitalWrite(SPI1_CS, LOW);
 	NERduino.writeSPI1(cmd, 4, ltcSPISettings);
 	for (int i = 0; i<len*3; i++)

--- a/shepherd_bms/platformio.ini
+++ b/shepherd_bms/platformio.ini
@@ -15,3 +15,4 @@ framework = arduino
 lib_deps = 
     Wire
     SPI
+monitor_speed = 57600

--- a/shepherd_bms/src/segment.cpp
+++ b/shepherd_bms/src/segment.cpp
@@ -12,12 +12,16 @@ void SegmentInterface::init()
 
     LTC6804_initialize();
 
-    // Turn OFF GPIO 1 & 2 pull downs and set all cells to NOT discharge
-    pullChipConfigurations();
+    //pullChipConfigurations();
+    
     for (int c = 0; c < NUM_CHIPS; c++)
     {
-        localConfig[c][0] |= 0x18;
-        configureDischarge(c, 0);
+    localConfig[c][0] = 0xF8;
+    localConfig[c][1] = 0x19; // VUV = 0x619 = 1561 -> 2.4992V
+    localConfig[c][2] = 0x06; // VOV = 0xA60 = 2656 -> 4.2496V
+    localConfig[c][3] = 0xA6;
+    localConfig[c][4] = 0x00;
+    localConfig[c][5] = 0x00;
     }
     pushChipConfigurations();
 }
@@ -188,6 +192,7 @@ FaultStatus_t SegmentInterface::pullVoltages()
 
     uint16_t segmentVoltages[NUM_CHIPS][12];
 
+    pushChipConfigurations();
     LTC6804_adcv();
 
     /**
@@ -237,13 +242,12 @@ FaultStatus_t SegmentInterface::pullThermistors()
     for (int therm = 1; therm <= 16; therm++)
 	{
         SelectTherm(therm);
-        delay(25);
+        delay(5);
         SelectTherm(therm + 16);
-        delay(25);
+        delay(5);
 		
 		pushChipConfigurations();
         LTC6804_adax(); // Run ADC for AUX (GPIOs and refs)
-        delay(10);
         LTC6804_rdaux(0, NUM_CHIPS, rawTempVoltages); // Fetch ADC results from AUX registers
 
         for (int c = 0; c < NUM_CHIPS; c++)
@@ -272,6 +276,7 @@ void SegmentInterface::SelectTherm(uint8_t therm)
 		i2cWriteData[chip][2] = 0x00;
 		}
 		serializeI2CMsg(i2cWriteData, commRegData);
+        pushChipConfigurations();
 		LTC6804_wrcomm(NUM_CHIPS, commRegData);
 		LTC6804_stcomm(24);
 
@@ -282,6 +287,7 @@ void SegmentInterface::SelectTherm(uint8_t therm)
 		i2cWriteData[chip][2] = 0x00;
 		}
 		serializeI2CMsg(i2cWriteData, commRegData);
+        pushChipConfigurations();
 		LTC6804_wrcomm(NUM_CHIPS, commRegData);
 		LTC6804_stcomm(24);
 	} else if (therm <= 16) {
@@ -292,6 +298,7 @@ void SegmentInterface::SelectTherm(uint8_t therm)
 		i2cWriteData[chip][2] = 0x00;
 		}
 		serializeI2CMsg(i2cWriteData, commRegData);
+        pushChipConfigurations();
 		LTC6804_wrcomm(NUM_CHIPS, commRegData);
 		LTC6804_stcomm(24);
 
@@ -302,6 +309,7 @@ void SegmentInterface::SelectTherm(uint8_t therm)
 		i2cWriteData[chip][2] = 0x00;
 		}
 		serializeI2CMsg(i2cWriteData, commRegData);
+        pushChipConfigurations();
 		LTC6804_wrcomm(NUM_CHIPS, commRegData);
 		LTC6804_stcomm(24);
 	} else if (therm <= 24) {
@@ -312,6 +320,7 @@ void SegmentInterface::SelectTherm(uint8_t therm)
 		i2cWriteData[chip][2] = 0x00;
 		}
 		serializeI2CMsg(i2cWriteData, commRegData);
+        pushChipConfigurations();
 		LTC6804_wrcomm(NUM_CHIPS, commRegData);
 		LTC6804_stcomm(24);
 
@@ -322,6 +331,7 @@ void SegmentInterface::SelectTherm(uint8_t therm)
 		i2cWriteData[chip][2] = 0x00;
 		}
 		serializeI2CMsg(i2cWriteData, commRegData);
+        pushChipConfigurations();
 		LTC6804_wrcomm(NUM_CHIPS, commRegData);
 		LTC6804_stcomm(24);
 	} else {
@@ -332,6 +342,7 @@ void SegmentInterface::SelectTherm(uint8_t therm)
 		i2cWriteData[chip][2] = 0x00;
 		}
 		serializeI2CMsg(i2cWriteData, commRegData);
+        pushChipConfigurations();
 		LTC6804_wrcomm(NUM_CHIPS, commRegData);
 		LTC6804_stcomm(24);
 
@@ -342,6 +353,7 @@ void SegmentInterface::SelectTherm(uint8_t therm)
 		i2cWriteData[chip][2] = 0x00;
 		}
 		serializeI2CMsg(i2cWriteData, commRegData);
+        pushChipConfigurations();
 		LTC6804_wrcomm(NUM_CHIPS, commRegData);
 		LTC6804_stcomm(24);
 	}

--- a/shepherd_bms/src/segment.cpp
+++ b/shepherd_bms/src/segment.cpp
@@ -237,19 +237,19 @@ FaultStatus_t SegmentInterface::pullThermistors()
     for (int therm = 1; therm <= 16; therm++)
 	{
         SelectTherm(therm);
-        delay(10);
+        delay(25);
         SelectTherm(therm + 16);
-        delay(15);
+        delay(25);
 		
 		pushChipConfigurations();
         LTC6804_adax(); // Run ADC for AUX (GPIOs and refs)
-        delay(20);
+        delay(10);
         LTC6804_rdaux(0, NUM_CHIPS, rawTempVoltages); // Fetch ADC results from AUX registers
 
         for (int c = 0; c < NUM_CHIPS; c++)
 		{
-            segmentData[c].thermistorReading[therm - 1] = steinhartEst(uint16_t(rawTempVoltages[c][0] * (float(rawTempVoltages[c][2]) / 50000)));
-            segmentData[c].thermistorReading[therm + 15] = steinhartEst(uint16_t(rawTempVoltages[c][1] * (float(rawTempVoltages[c][2]) / 50000)));
+            segmentData[c].thermistorReading[therm - 1] = uint16_t(rawTempVoltages[c][0] * (float(rawTempVoltages[c][2]) / 50000));
+            segmentData[c].thermistorReading[therm + 15] = uint16_t(rawTempVoltages[c][1] * (float(rawTempVoltages[c][2]) / 50000));
         }
     }
 	thermTimer.startTimer(THERM_WAIT_TIME);


### PR DESCRIPTION
This is a misc PR for everything that we had to do to get segments working during bringup, quick list of things that we did:

* Sending a wakeup command each time we send an I2C message with stcomm()
* pushing the chip config each time we read the cell adc's to run another conversion

This PR results in correctly getting the therm values and the cell values each time