### PR TITLE
106 fractionalcurrent

### DIFF
--- a/shepherd_bms/include/datastructs.h
+++ b/shepherd_bms/include/datastructs.h
@@ -79,7 +79,7 @@ struct AccumulatorData_t
 
     FaultStatus_t faultStatus = NOT_FAULTED;
 
-    int16_t packCurrent;
+    int16_t packCurrent;                        // this value is multiplied by 10 to account for decimal precision
     uint16_t packVoltage;
     uint16_t packRes;
 

--- a/shepherd_bms/src/analyzer.cpp
+++ b/shepherd_bms/src/analyzer.cpp
@@ -325,7 +325,7 @@ void Analyzer::calcOpenCellVoltage()
         }
     }
     // If we are within the current threshold for open voltage measurments
-    else if (bmsdata->packCurrent < OCV_CURR_THRESH && bmsdata->packCurrent > -OCV_CURR_THRESH) 
+    else if (bmsdata->packCurrent < (OCV_CURR_THRESH * 10) && bmsdata->packCurrent > (-OCV_CURR_THRESH * 10)) 
     {
         AccumulatorData_t prevbmsdata = head->next->data;
 

--- a/shepherd_bms/src/compute.cpp
+++ b/shepherd_bms/src/compute.cpp
@@ -98,7 +98,7 @@ int16_t ComputeInterface::getPackCurrent()
 
 
     uint16_t highCurrent = (5 / current_supplyVoltage) * (analogRead(CURRENT_SENSOR_PIN_H) * current_ADCResolution - current_highChannelOffset) * highChannelGain; // Channel has a large range with low resolution
-    uint16_t lowCurrent = 10 * (5 / current_supplyVoltage) * (analogRead(CURRENT_SENSOR_PIN_L) * current_ADCResolution - current_lowChannelOffset) * lowChannelGain; // Channel has a small range with high resolution
+    int16_t lowCurrent = 10 * (5 / current_supplyVoltage) * (analogRead(CURRENT_SENSOR_PIN_L) * current_ADCResolution - current_lowChannelOffset) * lowChannelGain; // Channel has a small range with high resolution
 
     // If the current is scoped within the range of the low channel, use the low channel
     if(lowCurrent < current_lowChannelMax - 5.0 || lowCurrent > current_lowChannelMin + 5.0)

--- a/shepherd_bms/src/compute.cpp
+++ b/shepherd_bms/src/compute.cpp
@@ -97,7 +97,7 @@ int16_t ComputeInterface::getPackCurrent()
     static const float lowChannelGain = 1 / 0.0267;
 
 
-    uint16_t highCurrent = (5 / current_supplyVoltage) * (analogRead(CURRENT_SENSOR_PIN_H) * current_ADCResolution - current_highChannelOffset) * highChannelGain; // Channel has a large range with low resolution
+    int16_t highCurrent = 10 * (5 / current_supplyVoltage) * (analogRead(CURRENT_SENSOR_PIN_H) * current_ADCResolution - current_highChannelOffset) * highChannelGain; // Channel has a large range with low resolution
     int16_t lowCurrent = 10 * (5 / current_supplyVoltage) * (analogRead(CURRENT_SENSOR_PIN_L) * current_ADCResolution - current_lowChannelOffset) * lowChannelGain; // Channel has a small range with high resolution
 
     // If the current is scoped within the range of the low channel, use the low channel

--- a/shepherd_bms/src/compute.cpp
+++ b/shepherd_bms/src/compute.cpp
@@ -98,7 +98,7 @@ int16_t ComputeInterface::getPackCurrent()
 
 
     uint16_t highCurrent = (5 / current_supplyVoltage) * (analogRead(CURRENT_SENSOR_PIN_H) * current_ADCResolution - current_highChannelOffset) * highChannelGain; // Channel has a large range with low resolution
-    float lowCurrent = (5 / current_supplyVoltage) * (analogRead(CURRENT_SENSOR_PIN_L) * current_ADCResolution - current_lowChannelOffset) * lowChannelGain; // Channel has a small range with high resolution
+    uint16_t lowCurrent = 10 * (5 / current_supplyVoltage) * (analogRead(CURRENT_SENSOR_PIN_L) * current_ADCResolution - current_lowChannelOffset) * lowChannelGain; // Channel has a small range with high resolution
 
     // If the current is scoped within the range of the low channel, use the low channel
     if(lowCurrent < current_lowChannelMax - 5.0 || lowCurrent > current_lowChannelMin + 5.0)

--- a/shepherd_bms/src/main.cpp
+++ b/shepherd_bms/src/main.cpp
@@ -138,7 +138,7 @@ void broadcastCurrentLimit(AccumulatorData_t *bmsdata)
 		BoostState = BOOST_STANDBY;
 	}
 	//Transition to boosting
-	if(bmsdata->packCurrent > (int16_t)bmsdata->contDCL && BoostState == BOOST_STANDBY)
+	if((bmsdata->packCurrent)/10 > (int16_t)bmsdata->contDCL && BoostState == BOOST_STANDBY)
 	{
 		BoostState = BOOSTING;
 		boostTimer.startTimer(BOOST_TIME);
@@ -166,7 +166,7 @@ const void printBMSStats(AccumulatorData_t *accData)
 	if(!debug_statTimer.isTimerExpired()) return;
 
 	Serial.print("Current: ");
-	Serial.println(accData->packCurrent);
+	Serial.println((accData->packCurrent)/10);
 	Serial.print("Min, Max, Avg Temps: ");
 	Serial.print(accData->minTemp.val);
 	Serial.print(",  ");
@@ -243,7 +243,7 @@ uint32_t faultCheck(AccumulatorData_t *accData)
 	uint32_t faultStatus = 0;
 
 	// Over current fault for discharge
-	if (accData->packCurrent > accData->dischargeLimit) 
+	if ((accData->packCurrent)/10 > accData->dischargeLimit) 
 	{
 		overCurrCount++;
 		if (overCurrCount > 10) 
@@ -256,7 +256,7 @@ uint32_t faultCheck(AccumulatorData_t *accData)
 	}
 
 	// Over current fault for charge
-	if (accData->packCurrent < 0 && abs(accData->packCurrent) > accData->chargeLimit) 
+	if ((accData->packCurrent)/10 < 0 && abs((accData->packCurrent)/10) > accData->chargeLimit) 
 	{
 		overChgCurrCount++;
 		if (overChgCurrCount > 100) 

--- a/shepherd_bms/src/main.cpp
+++ b/shepherd_bms/src/main.cpp
@@ -138,7 +138,7 @@ void broadcastCurrentLimit(AccumulatorData_t *bmsdata)
 		BoostState = BOOST_STANDBY;
 	}
 	//Transition to boosting
-	if((bmsdata->packCurrent)/10 > (int16_t)bmsdata->contDCL && BoostState == BOOST_STANDBY)
+	if((bmsdata->packCurrent) > ((bmsdata->contDCL)*10) && BoostState == BOOST_STANDBY)
 	{
 		BoostState = BOOSTING;
 		boostTimer.startTimer(BOOST_TIME);
@@ -243,7 +243,7 @@ uint32_t faultCheck(AccumulatorData_t *accData)
 	uint32_t faultStatus = 0;
 
 	// Over current fault for discharge
-	if ((accData->packCurrent)/10 > accData->dischargeLimit) 
+	if ((accData->packCurrent) > ((accData->dischargeLimit)*10))
 	{
 		overCurrCount++;
 		if (overCurrCount > 10) 
@@ -256,7 +256,7 @@ uint32_t faultCheck(AccumulatorData_t *accData)
 	}
 
 	// Over current fault for charge
-	if ((accData->packCurrent)/10 < 0 && abs((accData->packCurrent)/10) > accData->chargeLimit) 
+	if ((accData->packCurrent) < 0 && abs((accData->packCurrent)) > ((accData->chargeLimit)*10))
 	{
 		overChgCurrCount++;
 		if (overChgCurrCount > 100) 


### PR DESCRIPTION
## Issue ticket number and issue description
#106 fractional current

I multiplied pack current by 10 to allow for single decimal precision. I then divided it by 10 for all calcs (that did not care about decimal) to ensure all existing calculations were unaffected. 

Please double check that my manipulation of the value is done correctly and that I didn't miss any instances. where it is used

I also did not: 

divide packCurrent by 10 when broadcasting (idk if we wanna see decimal for this or not)
adjust open cell voltage calc to use this
add this value to charging stuff (not merged in yet)

lmk if any of those should be done here 
