### PR TITLE
State canmsg

### DIFF
--- a/shepherd_bms/include/compute.h
+++ b/shepherd_bms/include/compute.h
@@ -124,16 +124,14 @@ class ComputeInterface
       /**
       * @brief sends BMS status message 
       * 
-      * @param failsafe
-      * @param dtc_1
-      * @param dtc_2
-      * @param current_limit
+      * @param bms_state
+      * @param fault_status
       * @param avg_temp
       * @param internal_temp
       * 
       * @return Returns a fault if we are not able to send
       */
-      void sendBMSStatusMessage(uint8_t failsafe, uint8_t dtc_1, uint16_t dtc_2, uint16_t current_limit, int8_t avg_temp, int8_t internal_temp);
+      void sendBMSStatusMessage(BMSState_t bms_state, BMSFault_t fault_status, int8_t avg_temp, int8_t internal_temp);
 
       /**
       * @brief sends shutdown control message
@@ -171,15 +169,6 @@ class ComputeInterface
       void sendCellVoltageMessage(uint8_t cell_id, uint16_t instant_volt, uint16_t internal_res, uint8_t shunted, uint16_t open_voltage);
 
       /**
-      * @brief sends "is charging" message
-      * 
-      * @param charging_status
-      *
-      * @return Returns a fault if we are not able to send
-      */
-      void sendChargingStatus(bool charging_status);
-
-      /**
        * @brief sends out the calculated values of currents
        * 
        * @param discharge 
@@ -188,14 +177,7 @@ class ComputeInterface
        */
       void sendCurrentsStatus(uint16_t discharge, uint16_t charge, uint16_t current);
 
-      /**
-       * @brief Sends out the BMS fault status
-       * 
-       * @param fault_status 
-       */
-      void sendFaultStatus(BMSFault_t fault_status);
-
-      void sendState(BMSState_t state);
+      
 };
 
 extern ComputeInterface compute;

--- a/shepherd_bms/include/compute.h
+++ b/shepherd_bms/include/compute.h
@@ -4,6 +4,7 @@
 #include "datastructs.h"
 #include "nerduino.h"
 #include "canMsgHandler.h"
+#include "stateMachine.h"
 
 #define CURRENT_SENSOR_PIN_L  A1
 #define CURRENT_SENSOR_PIN_H  A0
@@ -193,6 +194,8 @@ class ComputeInterface
        * @param fault_status 
        */
       void sendFaultStatus(BMSFault_t fault_status);
+
+      void sendState(BMSState_t state);
 };
 
 extern ComputeInterface compute;

--- a/shepherd_bms/src/compute.cpp
+++ b/shepherd_bms/src/compute.cpp
@@ -344,3 +344,11 @@ void ComputeInterface::sendFaultStatus(BMSFault_t fault_status)
 
     sendMessageCAN1(0x09, 4, fault_status_msg.msg);
 }
+
+void ComputeInterface::sendState(BMSState_t state)
+{
+
+   uint8_t bms_state[1] = {state};
+
+   sendMessageCAN1(0xFF, 1, bms_state); //todo update ID with actual value when created
+}

--- a/shepherd_bms/src/compute.cpp
+++ b/shepherd_bms/src/compute.cpp
@@ -155,7 +155,7 @@ void ComputeInterface::sendAccStatusMessage(uint16_t voltage, int16_t current, u
     sendMessageCAN1(CANMSG_BMSACCSTATUS, 8, accStatusMsg.msg);
 }
 
-void ComputeInterface::sendBMSStatusMessage(uint8_t failsafe, uint8_t dtc_1, uint16_t dtc_2, uint16_t current_limit, int8_t avg_temp, int8_t internal_temp)
+void ComputeInterface::sendBMSStatusMessage(BMSState_t bms_state, BMSFault_t fault_status, int8_t avg_temp, int8_t internal_temp)
 {
     union 
     {
@@ -163,24 +163,19 @@ void ComputeInterface::sendBMSStatusMessage(uint8_t failsafe, uint8_t dtc_1, uin
 
         struct
         {
-            uint8_t fsStatus;
-            uint8_t dtcStatus1;
-            uint16_t dtcStatus2;
-            uint16_t currentLimit;
-            uint8_t tempAvg;
-            uint8_t tempInternal;
+            uint8_t state;
+            uint32_t fault;
+            uint8_t temp_avg;
+            uint8_t temp_internal;
         } cfg;   
-    } BMSStatusMsg;
+    } bmsStatusMsg;
 
-    BMSStatusMsg.cfg.fsStatus = failsafe;
-    BMSStatusMsg.cfg.dtcStatus1 = dtc_1;
-    BMSStatusMsg.cfg.dtcStatus2 = __builtin_bswap16(dtc_2);
-    BMSStatusMsg.cfg.currentLimit = __builtin_bswap16(current_limit);
-    BMSStatusMsg.cfg.tempAvg = static_cast<uint8_t>(avg_temp);
-    BMSStatusMsg.cfg.tempInternal = static_cast<uint8_t>(internal_temp);
+    bmsStatusMsg.cfg.state = bms_state;
+    bmsStatusMsg.cfg.temp_avg = static_cast<uint8_t>(avg_temp);
+    bmsStatusMsg.cfg.temp_internal = static_cast<uint8_t>(internal_temp);
 
     
-    sendMessageCAN1(CANMSG_BMSDTCSTATUS, 8, BMSStatusMsg.msg);
+    sendMessageCAN1(CANMSG_BMSDTCSTATUS, 8, bmsStatusMsg.msg);
 }
 
 void ComputeInterface::sendShutdownControlMessage(uint8_t mpe_state)
@@ -272,13 +267,6 @@ void ComputeInterface::sendCurrentsStatus(uint16_t discharge, uint16_t charge, u
     sendMessageCAN1(CANMSG_BMSCURRENTS, 8, currentsStatusMsg.msg);
 }
 
-void ComputeInterface::sendChargingStatus(bool charging_status)
-{
-    uint8_t charging_array[1] = {charging_status};
-
-    sendMessageCAN1(CANMSG_BMSCHARGINGSTATE, 1, charging_array);
-}
-
 void ComputeInterface::MCCallback(const CAN_message_t &msg)
 {
     return;
@@ -326,29 +314,4 @@ uint8_t ComputeInterface::calcChargerLEDState(AccumulatorData_t *bms_data)
     return RED_GREEN_BLINKING;
   }
 
-}
-
-void ComputeInterface::sendFaultStatus(BMSFault_t fault_status)
-{
-    union
-    {
-        uint8_t msg[4] = {0, 0, 0, 0};
-
-        struct 
-        {
-            uint32_t faults;
-        } cfg;
-    } fault_status_msg;
-
-    fault_status_msg.cfg.faults = fault_status;
-
-    sendMessageCAN1(0x09, 4, fault_status_msg.msg);
-}
-
-void ComputeInterface::sendState(BMSState_t state)
-{
-
-   uint8_t bms_state[1] = {state};
-
-   sendMessageCAN1(0x0A, 1, bms_state);
 }

--- a/shepherd_bms/src/compute.cpp
+++ b/shepherd_bms/src/compute.cpp
@@ -350,5 +350,5 @@ void ComputeInterface::sendState(BMSState_t state)
 
    uint8_t bms_state[1] = {state};
 
-   sendMessageCAN1(0xFF, 1, bms_state); //todo update ID with actual value when created
+   sendMessageCAN1(0x0A, 1, bms_state);
 }

--- a/shepherd_bms/src/compute.cpp
+++ b/shepherd_bms/src/compute.cpp
@@ -171,6 +171,7 @@ void ComputeInterface::sendBMSStatusMessage(BMSState_t bms_state, BMSFault_t fau
     } bmsStatusMsg;
 
     bmsStatusMsg.cfg.state = bms_state;
+    bmsStatusMsg.cfg.fault = fault_status;
     bmsStatusMsg.cfg.temp_avg = static_cast<uint8_t>(avg_temp);
     bmsStatusMsg.cfg.temp_internal = static_cast<uint8_t>(internal_temp);
 

--- a/shepherd_bms/src/main.cpp
+++ b/shepherd_bms/src/main.cpp
@@ -389,13 +389,13 @@ void shepherdMain()
 			{
 				digitalWrite(CHARGE_SAFETY_RELAY, HIGH);
 				compute.enableCharging(true);
-				compute.sendChargingStatus(true);
+				
 			} 
 			else 
 			{
 				digitalWrite(CHARGE_SAFETY_RELAY, LOW);
 				compute.enableCharging(false);
-				compute.sendChargingStatus(false);
+				
 			}
 
 			// Check if we should balance


### PR DESCRIPTION
per discussion with @mccauleyma, refactored can ms 0x02 to :

- remove failsafe 
- remove dtc1 and dtc2 
- remove currentlimit (has its own msg)

- add BMS state
- add fault status

remove CAN msg 0x09 as depreciated (technically removed 0x0A as well but that only existed in an earlier commit of this branch)