### PR TITLE
implemented fault timers

### DIFF
--- a/shepherd_bms/include/bmsConfig.h
+++ b/shepherd_bms/include/bmsConfig.h
@@ -36,11 +36,11 @@
 #define OCV_AVG             3
 
 //Fault times
-#define OVER_CURR_TIME      10 //todo adjust these based on counter values
+#define OVER_CURR_TIME      10 //todo adjust these based on testing and/or counter values
 #define OVER_CHG_CURR_TIME  10
 #define UNDER_VOLT_TIME     10
 #define OVER_VOLT_TIME      10
 #define LOW_CELL_TIME       10
-#define HIGH_TEMP_TIME      10 
+#define HIGH_TEMP_TIME      60000 
 
 #endif

--- a/shepherd_bms/include/bmsConfig.h
+++ b/shepherd_bms/include/bmsConfig.h
@@ -35,4 +35,12 @@
 
 #define OCV_AVG             3
 
+//Fault times
+#define OVER_CURR_TIME      10 //todo adjust these based on counter values
+#define OVER_CHG_CURR_TIME  10
+#define UNDER_VOLT_TIME     10
+#define OVER_VOLT_TIME      10
+#define LOW_CELL_TIME       10
+#define HIGH_TEMP_TIME      10 
+
 #endif

--- a/shepherd_bms/include/stateMachine.h
+++ b/shepherd_bms/include/stateMachine.h
@@ -15,6 +15,19 @@ typedef enum
     NUM_STATES
 }BMSState_t;
 
+typedef enum
+	{
+		BEFORE_TIMER_START,
+		DURING_FAULT_EVAL
+	}FaultEvalState;
+
+//timers and fault states for each fault
+struct faultEval
+{
+	FaultEvalState faultEvalState = BEFORE_TIMER_START;
+	Timer faultTimer;
+};
+
 class StateMachine
 {
     private:
@@ -133,5 +146,7 @@ class StateMachine
         void balanceCells(AccumulatorData_t *bms_data);
 
         void broadcastCurrentLimit(AccumulatorData_t *bmsdata);
+
+
 
 #endif

--- a/shepherd_bms/lib/LTC/LTC68041.cpp
+++ b/shepherd_bms/lib/LTC/LTC68041.cpp
@@ -528,15 +528,14 @@ int8_t LTC6804_rdaux(uint8_t reg, //Determines which GPIO voltage register is re
 					//a.ii
 					for (uint8_t current_gpio = 0; current_gpio< GPIO_IN_REG; current_gpio++) // This loop parses the read back data into GPIO voltages, it
 					{
-					// loops once for each of the 3 gpio voltage codes in the register
+            // loops once for each of the 3 gpio voltage codes in the register
 
-					parsed_aux = data[data_counter] + (data[data_counter+1]<<8);              //Each gpio codes is received as two bytes and is combined to
-					// create the parsed gpio voltage code
+            parsed_aux = data[data_counter] + (data[data_counter+1]<<8);              //Each gpio codes is received as two bytes and is combined to
+            // create the parsed gpio voltage code
 
-					aux_codes[current_ic][current_gpio +((gpio_reg-1)*GPIO_IN_REG)] = parsed_aux;
-					data_counter=data_counter+2;                        //Because gpio voltage codes are two bytes the data counter
-					//must increment by two for each parsed gpio voltage code
-
+            aux_codes[current_ic][current_gpio +((gpio_reg-1)*GPIO_IN_REG)] = parsed_aux;
+            data_counter=data_counter+2;                        //Because gpio voltage codes are two bytes the data counter
+            //must increment by two for each parsed gpio voltage code
 					}
 					//a.iii
 					received_pec = (data[data_counter]<<8)+ data[data_counter+1];          //The received PEC for the current_ic is transmitted as the 7th and 8th
@@ -549,6 +548,11 @@ int8_t LTC6804_rdaux(uint8_t reg, //Determines which GPIO voltage register is re
 					}
 					else if (received_pec != data_pec)
 					{
+            if (retries == LTC_MAX_RETRIES)
+            {
+              aux_codes[current_ic][gpio_reg-1] = LTC_BAD_READ;
+              aux_codes[current_ic][gpio_reg] = LTC_BAD_READ;
+            }
 						pec_error = -1;
 					}
 

--- a/shepherd_bms/lib/LTC/LTC68041.h
+++ b/shepherd_bms/lib/LTC/LTC68041.h
@@ -50,7 +50,8 @@ Copyright 2013 Linear Technology Corp. (LTC)
 #ifndef LTC68041_H
 #define LTC68041_H
 
-#define LTC_MAX_RETRIES 5
+#define LTC_MAX_RETRIES 10
+#define LTC_BAD_READ 0xFEEEEEEE
 
 #include <nerduino.h>
 

--- a/shepherd_bms/src/stateMachine.cpp
+++ b/shepherd_bms/src/stateMachine.cpp
@@ -211,7 +211,7 @@ uint32_t StateMachine::faultCheck(AccumulatorData_t *accData)
 	uint32_t faultStatus = 0;
 
 	// Over current fault for discharge
-	   if (overCurr.faultEvalState == BEFORE_TIMER_START && (accData->pack_current) > ((accData->discharge_limit)*10))
+	if (overCurr.faultEvalState == BEFORE_TIMER_START && (accData->pack_current) > ((accData->discharge_limit)*10))
     {
         overCurr.faultTimer.startTimer(OVER_CURR_TIME);
         overCurr.faultEvalState = DURING_FAULT_EVAL;
@@ -222,7 +222,7 @@ uint32_t StateMachine::faultCheck(AccumulatorData_t *accData)
         {
             faultStatus |= DISCHARGE_LIMIT_ENFORCEMENT_FAULT;
         }
-        else if (!((accData->pack_current) > ((accData->discharge_limit)*10)))
+        if (!((accData->pack_current) > ((accData->discharge_limit)*10)))
         {
             overCurr.faultTimer.cancelTimer();
             overCurr.faultEvalState = BEFORE_TIMER_START;
@@ -241,7 +241,7 @@ uint32_t StateMachine::faultCheck(AccumulatorData_t *accData)
         {
             faultStatus |= CHARGE_LIMIT_ENFORCEMENT_FAULT;
         }
-        else if (!((accData->pack_current) < 0 && abs((accData->pack_current)) > ((accData->charge_limit)*10)))
+        if (!((accData->pack_current) < 0 && abs((accData->pack_current)) > ((accData->charge_limit)*10)))
         {
             overChgCurr.faultTimer.cancelTimer();
             overChgCurr.faultEvalState = BEFORE_TIMER_START;
@@ -260,7 +260,7 @@ uint32_t StateMachine::faultCheck(AccumulatorData_t *accData)
         {
             faultStatus |= CELL_VOLTAGE_TOO_LOW;
         }
-        else if (!(accData->min_voltage.val < MIN_VOLT * 10000))
+        if (!(accData->min_voltage.val < MIN_VOLT * 10000))
         {
             underVolt.faultTimer.cancelTimer();
             underVolt.faultEvalState = BEFORE_TIMER_START;
@@ -268,7 +268,7 @@ uint32_t StateMachine::faultCheck(AccumulatorData_t *accData)
     }
 
 	// High cell voltage fault
-	 if (overVolt.faultEvalState == BEFORE_TIMER_START && (((accData->max_voltage.val > MAX_VOLT * 10000) && digitalRead(CHARGE_DETECT) == HIGH) || (accData->max_voltage.val > MAX_CHARGE_VOLT * 10000)))
+	if (overVolt.faultEvalState == BEFORE_TIMER_START && (((accData->max_voltage.val > MAX_VOLT * 10000) && digitalRead(CHARGE_DETECT) == HIGH) || (accData->max_voltage.val > MAX_CHARGE_VOLT * 10000)))
     {
         overVolt.faultTimer.startTimer(OVER_VOLT_TIME);
         overVolt.faultEvalState = DURING_FAULT_EVAL;
@@ -279,7 +279,7 @@ uint32_t StateMachine::faultCheck(AccumulatorData_t *accData)
         {
             faultStatus |= CELL_VOLTAGE_TOO_HIGH;
         }
-        else if (!((accData->max_voltage.val > MAX_VOLT * 10000) && digitalRead(CHARGE_DETECT) == HIGH) || (accData->max_voltage.val > MAX_CHARGE_VOLT * 10000))
+        if (!((accData->max_voltage.val > MAX_VOLT * 10000) && digitalRead(CHARGE_DETECT) == HIGH) || (accData->max_voltage.val > MAX_CHARGE_VOLT * 10000))
         {
             overVolt.faultTimer.cancelTimer();
             overVolt.faultEvalState = BEFORE_TIMER_START;
@@ -287,7 +287,7 @@ uint32_t StateMachine::faultCheck(AccumulatorData_t *accData)
     }
 
 	// High Temp Fault
-  if (highTemp.faultEvalState == BEFORE_TIMER_START && (accData->max_temp.val > MAX_CELL_TEMP))
+	if (highTemp.faultEvalState == BEFORE_TIMER_START && (accData->max_temp.val > MAX_CELL_TEMP))
     {
         highTemp.faultTimer.startTimer(HIGH_TEMP_TIME);
         highTemp.faultEvalState = DURING_FAULT_EVAL;
@@ -298,7 +298,7 @@ uint32_t StateMachine::faultCheck(AccumulatorData_t *accData)
         {
             faultStatus |= PACK_TOO_HOT;
         }
-        else if (!(accData->max_temp.val > MAX_CELL_TEMP))
+        if (!(accData->max_temp.val > MAX_CELL_TEMP))
         {
             highTemp.faultTimer.cancelTimer();
             highTemp.faultEvalState = BEFORE_TIMER_START;
@@ -306,7 +306,7 @@ uint32_t StateMachine::faultCheck(AccumulatorData_t *accData)
     }
 
 	// Extremely low cell voltage fault
-	  if (lowCell.faultEvalState == BEFORE_TIMER_START && (accData->min_voltage.val < 900))
+	if (lowCell.faultEvalState == BEFORE_TIMER_START && (accData->min_voltage.val < 900))
     {
         lowCell.faultTimer.startTimer(LOW_CELL_TIME);
         lowCell.faultEvalState = DURING_FAULT_EVAL;
@@ -317,7 +317,7 @@ uint32_t StateMachine::faultCheck(AccumulatorData_t *accData)
         {
             faultStatus |= LOW_CELL_VOLTAGE;
         }
-        else if (!(accData->min_voltage.val < 900))
+        if (!(accData->min_voltage.val < 900))
         {
             lowCell.faultTimer.cancelTimer();
             lowCell.faultEvalState = BEFORE_TIMER_START;

--- a/shepherd_bms/src/stateMachine.cpp
+++ b/shepherd_bms/src/stateMachine.cpp
@@ -1,5 +1,11 @@
 #include "stateMachine.h"
 
+	faultEval overCurr;
+	faultEval overChgCurr;
+	faultEval underVolt;
+	faultEval overVolt;
+	faultEval lowCell;
+	faultEval highTemp;
 
 StateMachine::StateMachine()
 {
@@ -17,13 +23,6 @@ void StateMachine::initBoot()
 
 void StateMachine::handleBoot(AccumulatorData_t *bmsdata)
 {
-
-	overVoltCount = 0;
-	underVoltCount = 0;
-    overCurrCount = 0;
-    chargeOverVolt = 0;
-	overChgCurrCount = 0;
-    lowCellCount = 0;
 
 	prevAccData = nullptr;
 
@@ -212,84 +211,118 @@ uint32_t StateMachine::faultCheck(AccumulatorData_t *accData)
 	uint32_t faultStatus = 0;
 
 	// Over current fault for discharge
-	if ((accData->pack_current) > ((accData->discharge_limit)*10))
-	{
-		overCurrCount++;
-		if (overCurrCount > 10)
-		{ // 0.10 seconds @ 100Hz rate
-			faultStatus |= DISCHARGE_LIMIT_ENFORCEMENT_FAULT;
-		}
-	} else
-	{
-		overCurrCount = 0;
-	}
+	   if (overCurr.faultEvalState == BEFORE_TIMER_START && (accData->pack_current) > ((accData->discharge_limit)*10))
+    {
+        overCurr.faultTimer.startTimer(OVER_CURR_TIME);
+        overCurr.faultEvalState = DURING_FAULT_EVAL;
+    }
+    else if (overCurr.faultEvalState == DURING_FAULT_EVAL)
+    {
+        if (overCurr.faultTimer.isTimerExpired())
+        {
+            faultStatus |= DISCHARGE_LIMIT_ENFORCEMENT_FAULT;
+        }
+        else if (!((accData->pack_current) > ((accData->discharge_limit)*10)))
+        {
+            overCurr.faultTimer.cancelTimer();
+            overCurr.faultEvalState = BEFORE_TIMER_START;
+        }
+    }
 
 	// Over current fault for charge
-	if ((accData->pack_current) < 0 && abs((accData->pack_current)) > ((accData->charge_limit)*10))
-	{
-		overChgCurrCount++;
-		if (overChgCurrCount > 1000)
-		{ // 1 seconds @ 100Hz rate
-			faultStatus |= CHARGE_LIMIT_ENFORCEMENT_FAULT;
-		}
-	}
-	else
-	{
-		overChgCurrCount = 0;
-	}
+	if (overChgCurr.faultEvalState == BEFORE_TIMER_START && ((accData->pack_current) < 0 && abs((accData->pack_current)) > ((accData->charge_limit)*10)))
+    {
+        overChgCurr.faultTimer.startTimer(OVER_CHG_CURR_TIME);
+        overChgCurr.faultEvalState = DURING_FAULT_EVAL;
+    }
+    else if (overChgCurr.faultEvalState == DURING_FAULT_EVAL)
+    {
+        if (overChgCurr.faultTimer.isTimerExpired())
+        {
+            faultStatus |= CHARGE_LIMIT_ENFORCEMENT_FAULT;
+        }
+        else if (!((accData->pack_current) < 0 && abs((accData->pack_current)) > ((accData->charge_limit)*10)))
+        {
+            overChgCurr.faultTimer.cancelTimer();
+            overChgCurr.faultEvalState = BEFORE_TIMER_START;
+        }
+    }
 
 	// Low cell voltage fault
-	if (accData->min_voltage.val < MIN_VOLT * 10000)
-	{
-
-		underVoltCount++;
-		if (underVoltCount > 900)
-		{ // 9 seconds @ 100Hz rate
-			faultStatus |= CELL_VOLTAGE_TOO_LOW;
-		}
-	}
-	else
-	{
-		underVoltCount = 0;
-	}
+	if (underVolt.faultEvalState == BEFORE_TIMER_START && accData->min_voltage.val < MIN_VOLT * 10000)
+    {
+        underVolt.faultTimer.startTimer(UNDER_VOLT_TIME );
+        underVolt.faultEvalState = DURING_FAULT_EVAL;
+    }
+    else if (underVolt.faultEvalState == DURING_FAULT_EVAL)
+    {
+        if (underVolt.faultTimer.isTimerExpired())
+        {
+            faultStatus |= CELL_VOLTAGE_TOO_LOW;
+        }
+        else if (!(accData->min_voltage.val < MIN_VOLT * 10000))
+        {
+            underVolt.faultTimer.cancelTimer();
+            underVolt.faultEvalState = BEFORE_TIMER_START;
+        }
+    }
 
 	// High cell voltage fault
-	if (((accData->max_voltage.val > MAX_VOLT * 10000) && digitalRead(CHARGE_DETECT) == HIGH) || (accData->max_voltage.val > MAX_CHARGE_VOLT * 10000))
-	{ // Needs to be reimplemented with a flag for every cell in case multiple go over
-		overVoltCount++;
-		if (overVoltCount > 900) { // 9 seconds @ 100Hz rate
-			faultStatus |= CELL_VOLTAGE_TOO_HIGH;
-		}
-	}
-	else
-	{
-		overVoltCount = 0;
-	}
+	 if (overVolt.faultEvalState == BEFORE_TIMER_START && (((accData->max_voltage.val > MAX_VOLT * 10000) && digitalRead(CHARGE_DETECT) == HIGH) || (accData->max_voltage.val > MAX_CHARGE_VOLT * 10000)))
+    {
+        overVolt.faultTimer.startTimer(OVER_VOLT_TIME);
+        overVolt.faultEvalState = DURING_FAULT_EVAL;
+    }
+    else if (overVolt.faultEvalState == DURING_FAULT_EVAL)
+    {
+        if (overVolt.faultTimer.isTimerExpired())
+        {
+            faultStatus |= CELL_VOLTAGE_TOO_HIGH;
+        }
+        else if (!((accData->max_voltage.val > MAX_VOLT * 10000) && digitalRead(CHARGE_DETECT) == HIGH) || (accData->max_voltage.val > MAX_CHARGE_VOLT * 10000))
+        {
+            overVolt.faultTimer.cancelTimer();
+            overVolt.faultEvalState = BEFORE_TIMER_START;
+        }
+    }
 
 	// High Temp Fault
-	if (accData->max_temp.val > MAX_CELL_TEMP) {
-		highTempCount++;
-		if (highTempCount > 100) { // 1 seconds @ 100Hz rate
-			faultStatus |= PACK_TOO_HOT;
-		}
-	}
-	else
-	{
-		highTempCount = 0;
-	}
+  if (highTemp.faultEvalState == BEFORE_TIMER_START && (accData->max_temp.val > MAX_CELL_TEMP))
+    {
+        highTemp.faultTimer.startTimer(HIGH_TEMP_TIME);
+        highTemp.faultEvalState = DURING_FAULT_EVAL;
+    }
+    else if (highTemp.faultEvalState == DURING_FAULT_EVAL)
+    {
+        if (highTemp.faultTimer.isTimerExpired())
+        {
+            faultStatus |= PACK_TOO_HOT;
+        }
+        else if (!(accData->max_temp.val > MAX_CELL_TEMP))
+        {
+            highTemp.faultTimer.cancelTimer();
+            highTemp.faultEvalState = BEFORE_TIMER_START;
+        }
+    }
 
 	// Extremely low cell voltage fault
-	if (accData->min_voltage.val < 900)
-	{ // 90mV
-		lowCellCount++;
-		if (lowCellCount > 100) { // 1 seconds @ 100Hz rate
-			faultStatus |= LOW_CELL_VOLTAGE;
-		}
-	}
-	else
-	{
-		lowCellCount = 0;
-	}
+	  if (lowCell.faultEvalState == BEFORE_TIMER_START && (accData->min_voltage.val < 900))
+    {
+        lowCell.faultTimer.startTimer(LOW_CELL_TIME);
+        lowCell.faultEvalState = DURING_FAULT_EVAL;
+    }
+    else if (lowCell.faultEvalState == DURING_FAULT_EVAL)
+    {
+        if (lowCell.faultTimer.isTimerExpired())
+        {
+            faultStatus |= LOW_CELL_VOLTAGE;
+        }
+        else if (!(accData->min_voltage.val < 900))
+        {
+            lowCell.faultTimer.cancelTimer();
+            lowCell.faultEvalState = BEFORE_TIMER_START;
+        }
+    }
 
 	return faultStatus;
 }


### PR DESCRIPTION
this PR replaces fault counters with timers. Both the functionality itself and the timer length needs to be tested before merged, (timers are all set to 10ms right now, should be adjusted for sure)

copied over from Joey's work on #149